### PR TITLE
Update RGBA alpha parsing.

### DIFF
--- a/lib/crossdoc/version.rb
+++ b/lib/crossdoc/version.rb
@@ -1,3 +1,3 @@
 module CrossDoc
-  VERSION = '0.7.6'
+  VERSION = '0.7.7'
 end

--- a/vendor/assets/javascripts/crossdoc.js
+++ b/vendor/assets/javascripts/crossdoc.js
@@ -49,7 +49,7 @@
         var comps
         if (s.indexOf('rgba(') === 0) {
             comps = s.replace('rgba(', '').replace(')', '').split(', ')
-            return '#' + decToHex(comps.slice(0,3)).join('') + twoChars((parseFloat(comps[3])*255).toString(16))
+            return '#' + decToHex(comps.slice(0,3)).join('') + (parseFloat(comps[3]) * 255 | 1 << 8).toString(16).slice(1)
         }
         else if (s.indexOf('rgb(') === 0) {
             comps = s.replace('rgb(', '').replace(')', '').split(', ')


### PR DESCRIPTION
rgba colors with an alpha value of 0.7 (only one i tested) was throwing an invalid color error because it was returning b2.8.  I don't quite understand the bitwise operator but that along with multiplying by 2^8 and slicing the first char return the expected results: b2.  It's also able to handle everything else that was thrown at it while rendering a pdf an exam roster.