### PR TITLE
Support More Images

### DIFF
--- a/lib/crossdoc/pdf_render.rb
+++ b/lib/crossdoc/pdf_render.rb
@@ -275,7 +275,7 @@ module CrossDoc
 
     def download_images
       @doc.images.each do |h, image|
-        image.download @doc.images.count
+        image.download(skip_processing: @doc.images.count < 6)
       end
     end
 

--- a/lib/crossdoc/pdf_render.rb
+++ b/lib/crossdoc/pdf_render.rb
@@ -275,7 +275,7 @@ module CrossDoc
 
     def download_images
       @doc.images.each do |h, image|
-        image.download
+        image.download @doc.images.count
       end
     end
 

--- a/lib/crossdoc/tree.rb
+++ b/lib/crossdoc/tree.rb
@@ -37,11 +37,16 @@ module CrossDoc
           @io = open(@src.gsub('./', Dir.pwd + '/'))
         else # assume it's a URL
           @io = URI.open @src
-          if num_images < 6
+          if @is_svg || num_images < 6
             return
           end
           img = MiniMagick::Image.open @src
           img.geometry image_width
+          img.combine_options do |i|
+            i.background '#FFFFFF'
+            i.alpha 'remove'
+          end
+          img.format 'jpg'
           @io = URI.open img.path
         end
       end

--- a/lib/crossdoc/tree.rb
+++ b/lib/crossdoc/tree.rb
@@ -16,7 +16,7 @@ module CrossDoc
 
     attr_reader :io, :is_svg
 
-    def download(num_images)
+    def download(skip_processing: false)
       if @src.index('data:image/svg+xml;') == 0
         @is_svg = true
         raw = Base64.decode64 @src.gsub('data:image/svg+xml;base64,', '')
@@ -37,13 +37,14 @@ module CrossDoc
           @io = open(@src.gsub('./', Dir.pwd + '/'))
         else # assume it's a URL
           @io = URI.open @src
-          if @is_svg || num_images < 6
+          if @is_svg || skip_processing
             return
           end
           img = MiniMagick::Image.open @src
+          img_size = img.size
           img.combine_options do |i|
             i.quality 80
-            i.geometry image_width
+            i.geometry image_width(img_size)
             i.background '#FFFFFF'
             i.alpha 'remove'
           end
@@ -56,8 +57,8 @@ module CrossDoc
     # decrease width as image file size increases to decrease final pdf size
     # starts from 2 x page width (1024px)
     # 1MB -> 963px, 6MB -> 658px
-    def image_width
-      scale_amount = (@io.size/1024/16)
+    def image_width(file_size)
+      scale_amount = (file_size/1024/16)
       1024 - scale_amount
     end
 

--- a/lib/crossdoc/tree.rb
+++ b/lib/crossdoc/tree.rb
@@ -36,7 +36,13 @@ module CrossDoc
         elsif @src.index('./')==0
           @io = open(@src.gsub('./', Dir.pwd + '/'))
         else # assume it's a URL
-          @io = URI.open(@src)
+          @io = URI.open @src
+          if @src.include?('logo_images') || @io.size < 1.megabyte
+            return
+          end
+          img = MiniMagick::Image.open @src
+          img.geometry 1024 # double the max page width
+          @io = URI.open img.path
         end
       end
     end

--- a/lib/crossdoc/tree.rb
+++ b/lib/crossdoc/tree.rb
@@ -41,8 +41,9 @@ module CrossDoc
             return
           end
           img = MiniMagick::Image.open @src
-          img.geometry image_width
           img.combine_options do |i|
+            i.quality 80
+            i.geometry image_width
             i.background '#FFFFFF'
             i.alpha 'remove'
           end

--- a/lib/crossdoc/tree.rb
+++ b/lib/crossdoc/tree.rb
@@ -37,7 +37,7 @@ module CrossDoc
           @io = open(@src.gsub('./', Dir.pwd + '/'))
         else # assume it's a URL
           @io = URI.open @src
-          if @src.include?('logo_images') || num_images < 6
+          if num_images < 6
             return
           end
           img = MiniMagick::Image.open @src

--- a/lib/crossdoc/version.rb
+++ b/lib/crossdoc/version.rb
@@ -1,3 +1,3 @@
 module CrossDoc
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
https://terrier.tech/hub/posts/e279d541-75c6-4c32-8165-7295a28e2b90

By limiting the width of inserted images, more images can be included in the final PDF without a) hitting the emailable file size limit of ~20 MB and b) sacrificing too much of the image's quality.

Requires changes in [this Clypboard PR](https://github.com/Terrier-Tech/clypboard-server/pull/3266).