### PR TITLE
Hack: replace smartquotes with regular quotes

### DIFF
--- a/crossdoc.gemspec
+++ b/crossdoc.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'rake'
+  spec.add_dependency 'matrix'
   spec.add_dependency 'prawn', '~> 2.1.0'
   spec.add_dependency 'prawn-svg'
   spec.add_dependency 'activesupport', '>= 4.2.0'

--- a/lib/crossdoc/markdown_builder.rb
+++ b/lib/crossdoc/markdown_builder.rb
@@ -25,12 +25,18 @@ module CrossDoc
     def combine_text(children)
       children.map do |child|
         case child.type
-          when :em
-            "<em>#{child.children.first.value}</em>"
-          when :strong
-            "<strong>#{child.children.first.value}</strong>"
-          else
-            child.value
+        when :em
+          value = child.children.first.value.to_s
+          value.gsub!(/rsquo/, "'")
+          "<em>#{value}</em>"
+        when :strong
+          value = child.children.first.value.to_s
+          value.gsub!(/rsquo/, "'")
+          "<strong>#{child.children.first.value}</strong>"
+        else
+          value = child.value.to_s
+          value.gsub!(/rsquo/, "'")
+          value
         end
       end.join('')
     end

--- a/lib/crossdoc/markdown_builder.rb
+++ b/lib/crossdoc/markdown_builder.rb
@@ -31,14 +31,14 @@ module CrossDoc
     def combine_text(children)
       children.map do |child|
         case child.type
-        when :em
-          "<em>#{child.children.first.value}</em>"
-        when :strong
-          "<strong>#{child.children.first.value}</strong>"
-        when :smart_quote
-          SMART_QUOTES[child.value]
-        else
-          child.value
+          when :em
+            "<em>#{child.children.first.value}</em>"
+          when :strong
+            "<strong>#{child.children.first.value}</strong>"
+          when :smart_quote
+            SMART_QUOTES[child.value]
+          else
+            child.value
         end
       end.join('')
     end

--- a/lib/crossdoc/markdown_builder.rb
+++ b/lib/crossdoc/markdown_builder.rb
@@ -19,24 +19,26 @@ module CrossDoc
 
 
     private
-    
+
+    SMART_QUOTES = {
+      lsquo: "\u2018", # ‘
+      rsquo: "\u2019", # ’
+      ldquo: "\u201C", # “
+      rdquo: "\u201D", # ”
+    }
 
     # combines the text of all child elements into one string
     def combine_text(children)
       children.map do |child|
         case child.type
         when :em
-          value = child.children.first.value.to_s
-          value.gsub!(/rsquo/, "'")
-          "<em>#{value}</em>"
+          "<em>#{child.children.first.value.to_s}</em>"
         when :strong
-          value = child.children.first.value.to_s
-          value.gsub!(/rsquo/, "'")
-          "<strong>#{child.children.first.value}</strong>"
+          "<strong>#{child.children.first.value.to_s}</strong>"
+        when :smart_quote
+          SMART_QUOTES[child.value]
         else
-          value = child.value.to_s
-          value.gsub!(/rsquo/, "'")
-          value
+          child.value
         end
       end.join('')
     end

--- a/lib/crossdoc/markdown_builder.rb
+++ b/lib/crossdoc/markdown_builder.rb
@@ -32,9 +32,9 @@ module CrossDoc
       children.map do |child|
         case child.type
         when :em
-          "<em>#{child.children.first.value.to_s}</em>"
+          "<em>#{child.children.first.value}</em>"
         when :strong
-          "<strong>#{child.children.first.value.to_s}</strong>"
+          "<strong>#{child.children.first.value}</strong>"
         when :smart_quote
           SMART_QUOTES[child.value]
         else

--- a/test/input/markdown.md
+++ b/test/input/markdown.md
@@ -1,4 +1,5 @@
 # Header 1
+I'm u's'i'n'g a'p'o's't'r'o'p'h'e's
 
 ## Header 2
 

--- a/test/input/markdown.md
+++ b/test/input/markdown.md
@@ -1,5 +1,5 @@
 # Header 1
-I'm u's'i'n'g a'p'o's't'r'o'p'h'e's
+I'm using an "apostrophe"
 
 ## Header 2
 


### PR DESCRIPTION
[Billing invoice formatting issue](https://terrier.tech/hub/posts/2aca28bd-2a54-4b3f-80d2-5969d72df3a7)

We previously rendered the billing office invoice message without markdown (Clypboard -> `DocBuilder#build_promotion_notice` line 209 as of today, anyway). Ben changed this in January. Kramdown [converts quotes to typographic quotes](https://kramdown.gettalong.org/rdoc/Kramdown/Options.html):

> smart_quotes
> Defines the HTML entity names or code points for smart quote output
> The entities identified by entity name or code point that should be used for, in order, a left single quote, a right single quote, a left double and a right double quote are specified by separating them with commas.
> 
> Default: lsquo,rsquo,ldquo,rdquo
> Used by: HTML/Latex converter

Theoretically, passing `smart_quotes: %w[apos apos quot quot]` as an option to Kramdown should fix this - it did not. I also tried installing the Github Flavor Markdown parser and using that (pass `input: 'GFM'`) and that didn't work either. I'm not sure if it's because we're not actually doing anything using Kramdown after we initialize the document. When I call `.to_html` on it, the apostrophes look right, so that's my tentative theory. My solution around this was to restore the non?-typographic quotes before render...Not my favorite solution, so I welcome other ideas.

Here is what the bug looks like (you can run `test_markdown_builder` to generate this file too):
![CleanShot 2024-05-29 at 10 45 26@2x](https://github.com/TinyMission/crossdoc/assets/43075531/a164a3e0-a6e7-4ca4-8231-584fe30f3dd6)

With fix:
![CleanShot 2024-05-29 at 10 46 14@2x](https://github.com/TinyMission/crossdoc/assets/43075531/074b4ac3-61d3-4bb7-b150-8ed685ea1820)
