### PR TITLE
Add EditorJS builder to Document Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,22 @@ styles = {
 Currently, only the following constructs are supported by the Markdown parser:
 
 * Headers (levels 1-3)
+* Images
 * Paragraphs
 * Ordered and unordered lists
 * Inline *em* and **strong** spans 
+* Tables
 
+### EditorJS Integration
+
+The Ruby Builder is also capable of parsing EditorJS (or, again, a limited
+subset) using the `editor_js` method. The following block types are supported:
+
++ Paragraphs
++ Quotes (no captions)
++ Headers
++ Images (no captions or styling tweaks)
++ Tables (no styling tweaks)
 
 ### Rails Integration
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,30 @@
 
 CrossDoc is a platform-independent document interchange format.
 
-This is the Ruby server library and JavaScript client library for CrossDoc.
-It is the defacto standard implementation of CrossDoc PDF rendering.
+This is the Ruby server library and JavaScript client library for CrossDoc.  It
+is the defacto standard implementation of CrossDoc PDF rendering.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'crossdoc', github: 'TinyMission/crossdoc'
+``` sh
+gem 'crossdoc', github: 'TinyMission/crossdoc'
+```
 
 And then execute:
 
-    $ bundle
+``` sh
+$ bundle
+```
+
 
 Or install it yourself as:
 
-    $ gem install crossdoc
+``` sh
+$ gem install crossdoc
+```
+
 
 ## Usage
 
@@ -44,17 +52,18 @@ A basic document is structured like this:
 </div>
 ```
 
-There is one containing div with class *crossdoc*.
-Each page is it's own div with class *page*, and optional classes for formatting:
+There is one containing div with class `crossdoc`.  Each page is it's own div with
+class `page`, and optional classes for formatting:
 
-* Page size: *us-letter* (default) or *us-legal*
-* Page margin: *margin-50*, *margin-75*, or *margin-100* for 1/2", 3/4", or 1" margins, respectively
-* Decoration: *decorated* applies a simple white background, border, and drop shadow to the page
+* Page size: `us-letter` (default) or `us-legal`
+* Page margin: `margin-50`, `margin-75`, or `margin-100` for 1/2", 3/4", or 1" margins, respectively
+* Decoration: `decorated` applies a simple white background, border, and drop shadow to the page
 
-Inside each page, you place the markup for your document.
-The actual markup can be basically anything you want.
-The CrossDoc JavaScript library (see next section) will serialize the document structure and layout into a platform-neutral JSON format, which can then be sent to a server to render into a PDF.
-
+Inside each page, you place the markup for your document.  The actual markup can
+be basically anything you want.  The CrossDoc JavaScript library (see next
+section) will serialize the document structure and layout into a
+platform-neutral JSON format, which can then be sent to a server to render into
+a PDF.
 
 ### JavaScript API
 
@@ -66,12 +75,13 @@ doc.parse('document'); // parse the document, passed by id
 var json = doc.toJSON(); // serialize the document to JSON
 ```
 
-Once serialized, you can send the document to your server through an AJAX call or form parameter.
-
+Once serialized, you can send the document to your server through an AJAX call
+or form parameter.
 
 ### Ruby API
 
-On the server, the Ruby API lets you take a JSON document representation and render it to a PDF.
+On the server, the Ruby API lets you take a JSON document representation and
+render it to a PDF.
 
 ```ruby
 doc = CrossDoc::Document.new doc_json # create a document from a JSON string (or Hash)
@@ -79,12 +89,13 @@ renderer = CrossDoc::PdfRenderer.new doc # create a PDF renderer to render the d
 renderer.to_pdf 'path/to/output.pdf' # render the document to a PDF in the filesystem
 ```
 
-The renderer will download all images included in the document and render the contents to a PDF using the [Prawn](http://http://prawnpdf.org/) PDF library.
+The renderer will download all images included in the document and render the
+contents to a PDF using the [Prawn](http://http://prawnpdf.org/) PDF library.
 
+### Custom Fonts
 
-## Custom Fonts
-
-In order to user custom fonts inside the PDF, you must register the font family with the renderer: 
+In order to use custom fonts inside the PDF, you must register the font family
+with the renderer: 
 
 ```ruby
 renderer.register_font_family 'FontName', {
@@ -96,21 +107,27 @@ renderer.register_font_family 'FontName', {
 Only TTF fonts are currently supported. 
 
 
-## Pagination
+### Pagination
 
-CrossDoc includes an automatic pagination utility that will split a one-page document into multiple pages.
-It recursively traverses the document tree and tries to determine the best place to break the pages.
+CrossDoc includes an automatic pagination utility that will split a one-page
+document into multiple pages.  It recursively traverses the document tree and
+tries to determine the best place to break the pages.
 
-To use the pagination, create a Paginator then run it on the document. This should be done before rendering the document.
+To use the pagination, create a Paginator then run it on the document. This
+should be done before rendering the document.
 
 ```ruby
 CrossDoc::Paginator.new(options).run doc
 ```
 
-_options_ is a hash with the possible optional values:
+`options` is a hash with the possible optional values:
 
-* _num_levels_ (default 3): the number of document tree levels the paginator will traverse before giving up. Set higher for complex documents and lower if you don't want to split up elements at a certain level (like tables).
-* _max_pages*_ (default 10): the maximum number of pages to create. This only exists to compensate for pagination failures that cause the document to blow up.
+* `num_levels` (default 3): the number of document tree levels the paginator will
+  traverse before giving up. Set higher for complex documents and lower if you
+  don't want to split up elements at a certain level (like tables).
+* `max_pages` (default 10): the maximum number of pages to create. This only
+  exists to compensate for pagination failures that cause the document to blow
+  up.
 
 
 ### Ruby Builder
@@ -148,9 +165,11 @@ CrossDoc::PdfRenderer.new(doc).to_pdf 'path/to/output.pdf'
 ```
 
 
-## Markdown
+### Markdown
 
-The Ruby Builder is able to parse a (limited subset of) Markdown-formatted text (using the [Kramdown](https://github.com/gettalong/kramdown/) parser) and create the appropriate nodes in the document. Simply call the _markdown_ method on any builder node: 
+The Ruby Builder is able to parse a (limited subset of) Markdown-formatted text
+(using the [Kramdown](https://github.com/gettalong/kramdown/) parser) and create the appropriate nodes in the document.
+Simply call the `markdown` method on any builder node: 
 
 ```ruby
 page.div do |container|
@@ -158,9 +177,10 @@ page.div do |container|
 end
 ```
 
-_formatted_text_ is a string containing Markdown-formatted text.
-_style_ is an optional hash that lets you override the default styling for the generated nodes.
-You can override the font attributes, margin, and padding, using the uppercase tag name as the key:
+where `formatted_text` is a string containing Markdown-formatted text and  `style` is
+an optional hash that lets you override the default styling for the generated
+nodes.  You can override the font attributes, margin, and padding, using the
+uppercase tag name as the key:
 
 ```ruby
 styles = {
@@ -209,8 +229,6 @@ To use CrossDoc in a Rails application, simply include the gem in your Gemfile a
 // application.js or similar
 //= require crossdoc
 ```
-
-
 
 ## Contributing
 

--- a/lib/crossdoc.rb
+++ b/lib/crossdoc.rb
@@ -7,6 +7,7 @@ module CrossDoc
   require 'crossdoc/pdf_render'
   require 'crossdoc/builder'
   require 'crossdoc/paginator'
+  require 'crossdoc/editor_js_builder'
   require 'crossdoc/markdown_builder'
   require 'crossdoc/converter'
   require 'crossdoc/prawn_monkey_patches'

--- a/lib/crossdoc/builder.rb
+++ b/lib/crossdoc/builder.rb
@@ -162,6 +162,10 @@ module CrossDoc
       self.box.height + @margin.top + @margin.bottom
     end
 
+    def editor_js(content, style={})
+      EditorJsBuilder.new(self, style).build content
+    end
+
     def markdown(content, style={})
       MarkdownBuilder.new(self, style).build content
     end

--- a/lib/crossdoc/builder.rb
+++ b/lib/crossdoc/builder.rb
@@ -14,6 +14,8 @@ module CrossDoc
 
     raw_shadow :list_style
 
+    raw_shadow :list_level
+
     raw_shadow :text
 
     raw_shadow :font

--- a/lib/crossdoc/editor_js_builder.rb
+++ b/lib/crossdoc/editor_js_builder.rb
@@ -56,20 +56,19 @@ module CrossDoc
 
       list_bullet_style = element == 'UL' ? 'disc' : list['meta']['counterType']
 
-      render_nested_list(parent, element, list_bullet_style, list['items'])
-    end
-
-    def render_nested_list(parent, element, list_bullet_style, items)
       parent.node element, list_style: list_bullet_style do |list_node|
         @styler.style_node list_node
-        items.each do |item|
-          list_node.node 'LI' do |item_node|
-            @styler.style_node item_node
-            item_node.text = item['content']
-            list_bullet_style = element == 'UL' ? 'disc' : item['meta']['counterType']
-            render_nested_list(item_node, element, list_bullet_style, item['items']) if item['items'].any?
-          end
+        render_nested_list(list_node, list['items'])
+      end
+    end
+
+    def render_nested_list(parent, items, level = 0)
+      items.each do |item|
+        parent.node 'LI', list_level: level do |item_node|
+          @styler.style_node item_node
+          item_node.text = item['content']
         end
+        render_nested_list(parent, item['items'], level + 1) if item['items'].any?
       end
     end
 

--- a/lib/crossdoc/editor_js_builder.rb
+++ b/lib/crossdoc/editor_js_builder.rb
@@ -48,23 +48,26 @@ module CrossDoc
     def render_list(parent, list)
       return if list['items'].empty?
 
-      element = case list['type']
+      element = case list['style']
                 when 'ordered' then 'OL'
                 when 'unordered', 'checklist' then 'UL'
-                else throw "Unknown list type #{list['type']}"
+                else throw "Unknown list style '#{list['style']}'"
                 end
 
-      render_nested_list(parent, element, list['items'])
+      list_bullet_style = element == 'UL' ? 'disc' : list['meta']['counterType']
+
+      render_nested_list(parent, element, list_bullet_style, list['items'])
     end
 
-    def render_nested_list(parent, element, items)
-      parent.node element do |list_node|
+    def render_nested_list(parent, element, list_bullet_style, items)
+      parent.node element, list_style: list_bullet_style do |list_node|
         @styler.style_node list_node
         items.each do |item|
           list_node.node 'LI' do |item_node|
             @styler.style_node item_node
             item_node.text = item['content']
-            render_nested_list(item_node, element, item['items']) if item['items'].any?
+            list_bullet_style = element == 'UL' ? 'disc' : item['meta']['counterType']
+            render_nested_list(item_node, element, list_bullet_style, item['items']) if item['items'].any?
           end
         end
       end

--- a/lib/crossdoc/editor_js_builder.rb
+++ b/lib/crossdoc/editor_js_builder.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require_relative './styler'
+
+module CrossDoc
+  # Used by the Builder to include content from EditorJS
+  class EditorJsBuilder
+    def initialize(container, styles = {})
+      @container = container
+      @styler = Styler.new styles
+    end
+
+    def build(content)
+      content['blocks'].each do |block|
+        render_block(@container, block)
+      end
+    end
+
+    private
+
+    def render_paragraph(parent, paragraph)
+      return if paragraph['text'].empty?
+
+      parent.node 'P' do |paragraph_node|
+        @styler.style_node paragraph_node
+        paragraph_node.text = paragraph['text']
+      end
+    end
+
+    def render_quote(parent, quote)
+      return if quote['text'].empty?
+
+      parent.node 'BLOCKQUOTE' do |quote_node|
+        @styler.style_node quote_node
+        quote_node.text = quote['text']
+      end
+    end
+
+    def render_header(parent, header)
+      return if header['text'].empty?
+
+      parent.node "H#{header['level']}" do |header_node|
+        @styler.style_node header_node
+        header_node.text = header['text']
+      end
+    end
+
+    def render_list(parent, list)
+      return if list['items'].empty?
+
+      element = case list['type']
+                when 'ordered' then 'OL'
+                when 'unordered', 'checklist' then 'UL'
+                else throw "Unknown list type #{list['type']}"
+                end
+
+      render_nested_list(parent, element, list['items'])
+    end
+
+    def render_nested_list(parent, element, items)
+      parent.node element do |list_node|
+        @styler.style_node list_node
+        items.each do |item|
+          list_node.node 'LI' do |item_node|
+            @styler.style_node item_node
+            item_node.text = item['content']
+            render_nested_list(item_node, element, item['items']) if item['items'].any?
+          end
+        end
+      end
+    end
+
+    def render_image(parent, image)
+      parent.node 'IMG' do |image_node|
+        @styler.style_node image_node
+        image_source = image['file']['url']
+        image_node.image_src(image_source).dimensions => { width: image_width, height: image_height }
+        image_height = (image_height.to_f / image_width * parent.box.width) if image_width > parent.box.width
+        image_node.push_min_height image_height
+      end
+    end
+
+    def render_table(parent, table)
+      return if table['content'].empty?
+
+      parent.node 'TABLE' do |table_node|
+        @styler.style_node table_node
+
+        # No headings, render 'bare' table
+        unless table['withHeadings']
+          table.content.each { |row| render_table_row(table_node, row) }
+          break
+        end
+
+        render_thead(table_node, table['content'])
+        render_tbody(table_node, table['content'])
+      end
+    end
+
+    def render_thead(table_node, content)
+      table_node.node 'THEAD' do |header_node|
+        @styler.style_node header_node
+        header_node.node 'TR', block_orientation: 'horizontal' do |header_row_node|
+          @styler.style_node header_row_node
+          content[0].each do |header_item|
+            header_row_node.node 'TH' do |header_item_node|
+              @styler.style_node header_item_node
+              header_item_node.text = header_item
+            end
+          end
+        end
+      end
+    end
+
+    def render_tbody(table_node, content)
+      table_node.node 'TBODY' do |body_node|
+        @styler.style_node body_node
+        content.drop(1).each do |row|
+          render_table_row(body_node, row)
+        end
+      end
+    end
+
+    def render_table_row(parent, row)
+      parent.node 'TR', block_orientation: 'horizontal' do |row_node|
+        @styler.style_node row_node
+        row.each do |row_item|
+          row_node.node 'TD' do |row_item_node|
+            @styler.style_node row_item_node
+            row_item_node.text = row_item
+          end
+        end
+      end
+    end
+
+    def render_block(parent, block)
+      data = block['data']
+      case block['type']
+      when 'paragraph' then render_paragraph(parent, data)
+      when 'quote' then render_quote(parent, data)
+      when 'header' then render_header(parent, data)
+      when 'list' then render_list(parent, data)
+      when 'image' then render_image(parent, data)
+      when 'table' then render_table(parent, data)
+      else raise "Cannot render: #{block.to_s.upcase}"
+      end
+    end
+  end
+end

--- a/lib/crossdoc/pdf_render.rb
+++ b/lib/crossdoc/pdf_render.rb
@@ -454,6 +454,10 @@ module CrossDoc
 
       height = node.box.height
       pos = [node.box.x, ctx.parent.box.height - node.box.y]
+      if node.tag == 'LI'
+        list_level = node.list_level || 0
+        pos[0] += node.font.size * list_level
+      end
 
       ctx.pdf.bounding_box pos, width: node.box.width, height: height do
         ctx.render_node_background node

--- a/lib/crossdoc/styler.rb
+++ b/lib/crossdoc/styler.rb
@@ -89,6 +89,17 @@ module CrossDoc
       end
     end
 
+    def style_border(node, border_value)
+      if border_value.is_a? Hash
+        raw_border = { top: '0', right: '0', bottom: '0', left: '0' }.merge(border_value)
+        node.border_left raw_border[:left]
+        node.border_right raw_border[:right]
+        node.border_top raw_border[:top]
+        node.border_bottom raw_border[:bottom]
+      elsif border_value.is_a? String
+        node.border_all border_value
+      end
+    end
 
     # styles a builder node with the given tag (uses the node's tag by default)
     def style_node(node, tag=nil)
@@ -96,7 +107,7 @@ module CrossDoc
       node_style = @styles[tag] || {}
 
       node.default_font node_style[:font] || {}
-      node.border_all node_style[:border] if node_style[:border]
+      style_border(node, node_style[:border]) if node_style[:border].present?
       node.push_min_height node_style[:min_height] || 0
 
       unless node_style.has_key? :margin_cache

--- a/lib/crossdoc/styler.rb
+++ b/lib/crossdoc/styler.rb
@@ -36,12 +36,6 @@ module CrossDoc
       OL: {
         margin: {bottom: 12, left: 20}
       },
-      LI: {
-        font: {
-          size: 12,
-          line_height: 24
-        }
-      },
       TABLE: {
         border: '1px solid',
         margin: { bottom: 0.1.inches }

--- a/lib/crossdoc/styler.rb
+++ b/lib/crossdoc/styler.rb
@@ -43,8 +43,17 @@ module CrossDoc
         }
       },
       TABLE: {
-        border: '1.2px solid',
+        border: '1px solid',
         margin: { bottom: 0.1.inches }
+      },
+      TH: {
+        font: { size: 13, align: 'center' },
+      },
+      THEAD: {
+        border: { bottom: '0.2px solid' },
+      },
+      TR: {
+        border: { bottom: '0.2px solid' },
       },
       TD: {
         margin: {

--- a/lib/crossdoc/tree.rb
+++ b/lib/crossdoc/tree.rb
@@ -94,7 +94,7 @@ module CrossDoc
       assign_fields attrs
     end
 
-    simple_fields %i(id tag text src hash list_style start input_type input_value input_possible)
+    simple_fields %i[id tag text src hash list_style list_level start input_type input_value input_possible]
 
     object_field :background, Background
 


### PR DESCRIPTION
This pull request adds support for including EditorJS rich text content in the
document builder, similar to Markdown. It supports all currently configured
features in Clypboard's EditorJS configuration, excluding:

* Captions in images and quote blocks.
* Minor configuration parameters in images and tables.